### PR TITLE
Fix line endings: enforce LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.csv text eol=lf


### PR DESCRIPTION
## Summary

- Added `.gitattributes` with `*.csv text eol=lf` rule

All three CSV data files already use LF line endings. This rule prevents CRLF from reappearing on Windows checkouts or future automated regenerations.

## Files changed

- `.gitattributes` (new) — `*.csv text eol=lf`